### PR TITLE
fix: avoids changing parameters of OnGrid inside jax transformations

### DIFF
--- a/jaxdf/discretization.py
+++ b/jaxdf/discretization.py
@@ -175,20 +175,14 @@ class OnGrid(Linear):
       OnGrid: A linear discretization on the grid points of the domain.
     '''
     self.domain = domain
+
+    # Automatically add a dimension for scalar fields, if possible.
+    # See this for an explanation of the first if: https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization
+    if not (type(params) is object or params is None or isinstance(params, OnGrid)):
+      if len(params.shape) == len(self.domain.N):
+        params = jnp.expand_dims(params, -1)
+
     self.params = params
-
-  @property
-  def params(self):
-    return self._params
-
-  @params.setter
-  def params(self, value):
-    # Automatically add a dimension for scalar fields
-    if len(value.shape) == len(self.domain.N):
-      value = jnp.expand_dims(value, -1)
-      self._params = value
-    else:
-      self._params = value
 
   @property
   def dims(self):

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,23 @@
+from jaxdf import FourierSeries
+from jaxdf.geometry import Domain
+
+from jax import numpy as jnp
+import jax
+
+
+def test_vmap_over_ongrid():
+    # Checks for this:
+    # https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization
+    def foo(field, x):
+        return field
+
+    vfoo = jax.vmap(foo, in_axes=(None, 0))
+
+    N = (8,8)
+    params = jnp.ones(N)
+    domain = Domain(N, (1,1))
+
+    fs = FourierSeries(params, domain)
+    values = jnp.asarray([1,2,3,4])
+
+    print(vfoo(fs, values))


### PR DESCRIPTION
During the construction of `OnGrid` objects, the `params` field was implemented as a dynamic property using setters and getters. 
The reason was to ease the initialization of scalar fields, by avoiding the user to manually input and extra dimensions to numpy arrays that is used to specify the dimensionality of the field.
This was creating problems with `jax.vmap`, for reasons explained in [this page of the jax documentation](https://jax.readthedocs.io/en/latest/pytrees.html#custom-pytrees-and-initialization).

This PR fixes it and adds the required tests