### PR TITLE
removed jaxlib dependency

### DIFF
--- a/.github/actions/python-poetry-env/action.yml
+++ b/.github/actions/python-poetry-env/action.yml
@@ -19,3 +19,6 @@ runs:
     - name: Create virtual environment
       run: poetry install --with=dev
       shell: bash
+    - name: Install jaxlib
+      run: poetry run pip install --upgrade "jax[cpu]"
+      shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ packages = [
 python = "^3.9"
 plum-dispatch = "^1.6"
 jax = "^0.4.11"
-jaxlib = "^0.4.11"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.2.7"


### PR DESCRIPTION
Removing `jaxlib` from the dependencies.

Jax does not specifically list `jaxlib` in its dependencies due to its various hardware-specific versions (such as for CPU, GPU, TPU, and so on). Python's dependency management system lacks the necessary precision to handle this. This issue is resolved by JAX through its installation guidelines.

For more info: https://github.com/google/jax/discussions/16380